### PR TITLE
Update invalid next recurring task date

### DIFF
--- a/Tests/MongoQueueTests/MongoQueueTests.swift
+++ b/Tests/MongoQueueTests/MongoQueueTests.swift
@@ -59,6 +59,11 @@ struct RTRecurringTask: RecurringTask {
     var initialTaskExecutionDate: Date { Date() }
     
     var uniqueTaskKey: String = "RecurringTask"
+
+    func updateInvalidNextRecurringTaskDate(_ context: Void) async throws -> Date? {
+
+        return nil
+    }
     
     func getNextRecurringTaskDate(_ context: ExecutionContext) async throws -> Date? {
         MongoQueueTests.ranTasks >= 5 ? nil : Date()


### PR DESCRIPTION
Hi @Joannis,

I've added `updateInvalidNextRecurringTaskDate(_ context: ExecutionContext) async throws -> Date?` to trigger RecurringTask when the date is scheduled in the past.

This method will help us update schedule date in case of unavailable service or any case might happen in the future which causes the scheduler to miss an execution.