### PR TITLE
Fix example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ private struct MongoQueueStorageKey: StorageKey {
 }
 
 extension Application {
-  public var mongo: MongoQueue {
+  public var queue: MongoQueue {
     get {
       storage[MongoQueueStorageKey.self]!
     }


### PR DESCRIPTION
Renames `mongo` property to `queue`.
The example code was not compiling without this fix.